### PR TITLE
RUM-12611 Update readme for Apollo 2.0.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ dependencies: [
 Alternatively, you can add it using Xcode:
 1. Go to File → Add Package Dependencies
 2. Enter the repository URL: `https://github.com/DataDog/dd-sdk-ios-apollo-interceptor`
-3. Select version 1.x.x for Apollo iOS 1.0+ or version 2.x.x for Apollo iOS 2.0+
+3. Select the package version that matches your Apollo major version (choose 1.x.x for Apollo iOS 1.0+ or 2.x.x for Apollo iOS 2.0+).
 
 ## Initial setup
 
 ### For Apollo iOS 1.0+
 
-1. Set up RUM monitoring with the [Datadog iOS RUM SDK](https://docs.datadoghq.com/real_user_monitoring/ios/):
+1. Set up RUM monitoring with the [Datadog iOS SDK](https://docs.datadoghq.com/real_user_monitoring/ios/):
 2. Set up network instrumentation for Apollo's built-in URLSessionClient:
 
 ```swift
@@ -52,7 +52,7 @@ class CustomInterceptorProvider: DefaultInterceptorProvider {
 
 ### For Apollo iOS 2.0+
 
-1. Set up RUM monitoring with the [Datadog iOS RUM SDK](https://docs.datadoghq.com/real_user_monitoring/ios/):
+1. Set up RUM monitoring with the [Datadog iOS SDK](https://docs.datadoghq.com/real_user_monitoring/ios/):
 2. Set up network instrumentation.
 
 Apollo 2.0 requires creating a custom URLSession delegate (unlike Apollo 1.0 which uses the built-in `URLSessionClient`):
@@ -65,7 +65,7 @@ class ApolloURLSessionDelegate: NSObject, URLSessionDataDelegate {
 }
 ```
 
-Then enable instrumentation for your custom delegate:
+Then, enable instrumentation for your custom delegate:
 
 ```swift
 URLSessionInstrumentation.enable(with: .init(delegateClass: ApolloURLSessionDelegate.self))

--- a/README.md
+++ b/README.md
@@ -2,25 +2,39 @@
 
 ## Getting started
 
-**Note:** The integration supports Apollo iOS version 1.0+.
+> [!NOTE]
+> This integration supports both Apollo iOS 1.0+ and Apollo iOS 2.0+. The setup differs between versions, so please follow the instructions for your Apollo iOS version below.
 
 To include the integration for [Apollo iOS](https://github.com/apollographql/apollo-ios) in your project, add the following to your `Package.swift` file:
 
 ```swift
 dependencies: [
+    // For Apollo iOS 1.0+
     .package(url: "https://github.com/DataDog/dd-sdk-ios-apollo-interceptor", .upToNextMajor(from: "1.0.0"))
+    
+    // For Apollo iOS 2.0+
+    .package(url: "https://github.com/DataDog/dd-sdk-ios-apollo-interceptor", .upToNextMajor(from: "2.0.0"))
 ]
 ```
 
 Alternatively, you can add it using Xcode:
 1. Go to File → Add Package Dependencies
 2. Enter the repository URL: `https://github.com/DataDog/dd-sdk-ios-apollo-interceptor`
-3. Select the latest version
+3. Select version 1.x.x for Apollo iOS 1.0+ or version 2.x.x for Apollo iOS 2.0+
 
 ## Initial setup
 
-1. Set up RUM monitoring with [Datadog iOS RUM SDK](https://docs.datadoghq.com/real_user_monitoring/ios/)
-2. Set up network instrumentation with the Datadog RUM SDK for iOS
+### For Apollo iOS 1.0+
+
+1. Set up RUM monitoring with the [Datadog iOS RUM SDK](https://docs.datadoghq.com/real_user_monitoring/ios/):
+2. Set up network instrumentation for Apollo's built-in URLSessionClient:
+
+```swift
+import Apollo
+
+URLSessionInstrumentation.enable(with: .init(delegateClass: URLSessionClient.self))
+```
+
 3. Add the Datadog interceptor to your Apollo Client setup:
 
 ```swift
@@ -36,7 +50,62 @@ class CustomInterceptorProvider: DefaultInterceptorProvider {
 }
 ```
 
-This automatically adds Datadog headers to your GraphQL requests, enabling them to be tracked by Datadog. Note that while `query` and `mutation` operations are tracked, `subscription` operations are not.
+### For Apollo iOS 2.0+
+
+1. Set up RUM monitoring with the [Datadog iOS RUM SDK](https://docs.datadoghq.com/real_user_monitoring/ios/):
+2. Set up network instrumentation.
+
+Apollo 2.0 requires creating a custom URLSession delegate (unlike Apollo 1.0 which uses the built-in `URLSessionClient`):
+
+First, create a custom URLSession delegate class:
+
+```swift
+class ApolloURLSessionDelegate: NSObject, URLSessionDataDelegate {
+    // Datadog will automatically instrument this delegate
+}
+```
+
+Then enable instrumentation for your custom delegate:
+
+```swift
+URLSessionInstrumentation.enable(with: .init(delegateClass: ApolloURLSessionDelegate.self))
+```
+
+Configure your Apollo Client to use the custom URLSession with this delegate:
+
+```swift
+// Create custom URLSession with the delegate for Datadog tracking
+let configuration = URLSessionConfiguration.default
+let sessionDelegate = ApolloURLSessionDelegate()
+let customSession = URLSession(
+    configuration: configuration,
+    delegate: sessionDelegate,
+    delegateQueue: nil
+)
+
+// Pass the custom session to your RequestChainNetworkTransport
+let networkTransport = RequestChainNetworkTransport(
+    urlSession: customSession,
+    interceptorProvider: NetworkInterceptorProvider(),
+    store: store,
+    endpointURL: url
+)
+```
+
+3. Create an interceptor provider with the Datadog interceptor:
+
+```swift
+import Apollo
+import DatadogApollo
+
+struct NetworkInterceptorProvider: InterceptorProvider {
+    func graphQLInterceptors<Operation>(for operation: Operation) -> [any GraphQLInterceptor] where Operation : GraphQLOperation {
+        return [DatadogApolloInterceptor()] + DefaultInterceptorProvider.shared.graphQLInterceptors(for: operation)
+    }
+}
+```
+> [!NOTE]
+> This automatically adds Datadog headers to your GraphQL requests, enabling them to be tracked by Datadog. Note that while `query` and `mutation` operations are tracked, `subscription` operations are not.
 
 ## Sending GraphQL payloads
 

--- a/Sources/DatadogApollo/DatadogApolloInterceptor.swift
+++ b/Sources/DatadogApollo/DatadogApolloInterceptor.swift
@@ -16,7 +16,7 @@ import ApolloAPI
 /// and adds them as HTTP headers that can be consumed by Datadog RUM monitoring.
 public class DatadogApolloInterceptor: ApolloInterceptor, Identifiable {
     /// Unique identifier for this interceptor
-    public let id: String = UUID().uuidString
+    public var id: String = UUID().uuidString
 
     /// Whether to include the full GraphQL payload in headers
     private let sendGraphQLPayloads: Bool

--- a/tools/runner-setup.sh
+++ b/tools/runner-setup.sh
@@ -10,7 +10,6 @@
 #   --tvOS: Install the tvOS platform with the latest simulator if not already installed. Default: disabled.
 #   --visionOS: Install the visionOS platform with the latest simulator if not already installed. Default: disabled.
 #   --watchOS: Install the watchOS platform with the latest simulator if not already installed. Default: disabled.
-#   --ssh: Configure SSH for git operations. Default: disabled.
 #   --datadog-ci: Install 'datadog-ci' on the runner. Default: disabled.
 #   --python: Ensure Python 3 and pip are available. Default: disabled.
 
@@ -25,7 +24,6 @@ define_arg "iOS" "false" "Install the iOS platform with the latest simulator if 
 define_arg "tvOS" "false" "Install the tvOS platform with the latest simulator if not already installed. Default: disabled." "store_true"
 define_arg "visionOS" "false" "Install the visionOS platform with the latest simulator if not already installed. Default: disabled." "store_true"
 define_arg "watchOS" "false" "Install the watchOS platform with the latest simulator if not already installed. Default: disabled." "store_true"
-define_arg "ssh" "false" "Configure SSH for git operations. Default: disabled." "store_true"
 define_arg "datadog-ci" "false" "Install 'datadog-ci' on the runner. Default: disabled." "store_true"
 define_arg "python" "false" "Ensure Python 3 and pip are available. Default: disabled." "store_true"
 
@@ -100,30 +98,6 @@ if [ "$watchOS" = "true" ]; then
     echo_subtitle "Install watchOS platform"
     echo "▸ xcodebuild -downloadPlatform watchOS -quiet"
     xcodebuild -downloadPlatform watchOS -quiet
-fi
-
-if [ "$ssh" = "true" ]; then
-    # Adds SSH config, so we can git clone GH repos.
-    echo_subtitle "Add SSH configuration"
-    SSH_KEY_PATH="$HOME/.ssh/id_ed25519"
-    SSH_CONFIG_PATH="$HOME/.ssh/config"
-
-    if [ ! -f "$SSH_KEY_PATH" ] || [ ! -f "$SSH_CONFIG_PATH" ]; then
-        echo_warn "Found no SSH key or SSH config file. Configuring..."
-        get_secret $DD_APOLLO_SECRET__SSH_KEY > $SSH_KEY_PATH
-        chmod 600 "$SSH_KEY_PATH"
-
-        cat <<EOF > "$HOME/.ssh/config"
-Host github.com
-    HostName github.com
-    User git
-    IdentityFile $SSH_KEY_PATH
-    StrictHostKeyChecking no
-EOF
-        echo_succ "Finished SSH setup."
-    else
-        echo_succ "SSH key and config file already exist. Skipping..."
-    fi
 fi
 
 if [ "$datadog_ci" = "true" ]; then

--- a/tools/secrets/config.sh
+++ b/tools/secrets/config.sh
@@ -11,10 +11,8 @@ DD_APOLLO_SECRETS_PATH_PREFIX='kv/aws/arn:aws:iam::486234852809:role/ci-dd-sdk-i
 
 # Secrets needed for release process only
 DD_APOLLO_SECRET__CP_TRUNK_TOKEN="cocoapods.trunk.token"
-DD_APOLLO_SECRET__SSH_KEY="ssh.key"
 
 idx=0
 declare -A DD_APOLLO_SECRETS
 DD_APOLLO_SECRETS[$((idx++))]="$DD_APOLLO_SECRET__CP_TRUNK_TOKEN | Cocoapods token to authenticate 'pod trunk' operations (https://guides.cocoapods.org/terminal/commands.html)"
-DD_APOLLO_SECRETS[$((idx++))]="$DD_APOLLO_SECRET__SSH_KEY | SSH key to authenticate 'git clone git@github.com:...' operations"
 


### PR DESCRIPTION
### What and why?

Update the readme to mention the steps to setup Apollo Interceptor with Apollo 2.0.0+.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
