### PR TITLE
fix: change id property to var for Apollo iOS 1.x compatibility

### DIFF
--- a/Sources/DatadogApollo/DatadogApolloInterceptor.swift
+++ b/Sources/DatadogApollo/DatadogApolloInterceptor.swift
@@ -16,7 +16,7 @@ import ApolloAPI
 /// and adds them as HTTP headers that can be consumed by Datadog RUM monitoring.
 public class DatadogApolloInterceptor: ApolloInterceptor, Identifiable {
     /// Unique identifier for this interceptor
-    public let id: String = UUID().uuidString
+    public var id: String = UUID().uuidString
 
     /// Whether to include the full GraphQL payload in headers
     private let sendGraphQLPayloads: Bool


### PR DESCRIPTION
## Problem

The `DatadogApolloInterceptor` fails to compile with older Apollo iOS 1.x versions due to protocol conformance issues:

```
Type 'DatadogApolloInterceptor' does not conform to protocol 'ApolloInterceptor'
```

The `id` property was declared as `let`, but Apollo iOS versions prior to 1.8.0 require the `ApolloInterceptor` protocol's `id` property to be mutable (`var`) with `{ get set }` capabilities.

## Fix

Changed the `id` property from `let` to `var`. This satisfies all Apollo iOS 1.x protocol requirements:

- **Older versions (< 1.8.0):** Require `{ get set }` ✓
- **Newer versions (≥ 1.8.0):** Require `{ get }` ✓

## Testing

- Existing tests pass (they only read the property)
- No behavior changes (property is still initialized once and never mutated)
- Maintains backward and forward compatibility across all Apollo iOS 1.x versions

Fixes #16