### PR TITLE
Fix: JSON serialization crash with __SwiftValue types in GraphQLMetadataExtractor

### DIFF
--- a/Sources/DatadogApollo/Internal/GraphQLMetadataExtractor.swift
+++ b/Sources/DatadogApollo/Internal/GraphQLMetadataExtractor.swift
@@ -22,10 +22,20 @@ internal struct GraphQLMetadataExtractor {
             return nil
         }
 
-        // Use Apollo's built-in JSONEncodable conversion to handle proper serialization
-        let jsonEncodableDict = variables._jsonEncodableObject
+        // Convert each variable to its _jsonValue representation to ensure JSON-serializability.
+        // We use _jsonValue instead of _jsonEncodableObject to properly handle types like
+        // GraphQLEnum that need conversion before serialization.
+        let jsonValueDict = variables.mapValues { variableValue -> Any in
+            // Use _jsonEncodableValue to get the JSONEncodable, then extract _jsonValue
+            if let encodable = variableValue._jsonEncodableValue {
+                return encodable._jsonValue
+            }
+            // Fallback to the variable value itself if it doesn't have an encodable value
+            return variableValue
+        }
+
         do {
-            let jsonData = try JSONSerialization.data(withJSONObject: jsonEncodableDict, options: [])
+            let jsonData = try JSONSerialization.data(withJSONObject: jsonValueDict, options: [])
             return String(data: jsonData, encoding: .utf8)
         } catch {
             // If serialization fails, return nil to avoid breaking the request

--- a/Sources/DatadogApollo/Internal/GraphQLMetadataExtractor.swift
+++ b/Sources/DatadogApollo/Internal/GraphQLMetadataExtractor.swift
@@ -27,11 +27,8 @@ internal struct GraphQLMetadataExtractor {
         // GraphQLEnum that need conversion before serialization.
         let jsonValueDict = variables.mapValues { variableValue -> Any in
             // Use _jsonEncodableValue to get the JSONEncodable, then extract _jsonValue
-            if let encodable = variableValue._jsonEncodableValue {
-                return encodable._jsonValue
-            }
             // Fallback to the variable value itself if it doesn't have an encodable value
-            return variableValue
+            return variableValue._jsonEncodableValue?._jsonValue ?? variableValue
         }
 
         do {

--- a/Tests/DatadogApolloTests/DatadogApolloTests.swift
+++ b/Tests/DatadogApolloTests/DatadogApolloTests.swift
@@ -109,4 +109,24 @@ public final class DatadogApolloInterceptorTests: XCTestCase {
         XCTAssertTrue(payload.contains("query GetUser"))
         XCTAssertTrue(payload.contains("user(id: $userId)"))
     }
+
+    // MARK: - GraphQL Enum Variables Tests
+
+    func testExtractVariablesWithGraphQLEnum() throws {
+        // Test that GraphQLEnum types are properly serialized to JSON
+        let extractor = GraphQLMetadataExtractor()
+        let operation = MockOperationWithGraphQLEnum(id: "test-123", enumValue: .optionB)
+
+        let result = extractor.extractVariables(from: operation)
+
+        XCTAssertNotNil(result)
+        guard let variables = result else {
+            XCTFail("Expected non-nil variables")
+            return
+        }
+
+        // Verify the enum is serialized as its string value
+        XCTAssertTrue(variables.contains("OPTION_B"))
+        XCTAssertTrue(variables.contains("test-123"))
+    }
 }

--- a/Tests/DatadogApolloTests/TestMocks.swift
+++ b/Tests/DatadogApolloTests/TestMocks.swift
@@ -130,3 +130,32 @@ internal class MockNoVariablesOperation: GraphQLOperation {
 
     var __variables: [String: GraphQLOperationVariableValue]? = nil
 }
+
+// MARK: - Mock GraphQL Enum for Testing
+
+/// Mock enum for testing GraphQLEnum serialization
+internal enum MockEnumValue: String, Sendable, EnumType {
+    case optionA = "OPTION_A"
+    case optionB = "OPTION_B"
+    case optionC = "OPTION_C"
+}
+
+/// Mock operation with GraphQLEnum variables for testing serialization
+internal class MockOperationWithGraphQLEnum: GraphQLOperation {
+    typealias Data = MockData
+
+    static let operationName: String = "QueryWithEnum"
+    static let operationType: GraphQLOperationType = .query
+    static let operationDocument: ApolloAPI.OperationDocument = .init(
+        definition: .init("query QueryWithEnum($id: ID!, $enumValue: EnumValue!) { item(id: $id, enumValue: $enumValue) { id } }")
+    )
+
+    var __variables: [String: GraphQLOperationVariableValue]?
+
+    init(id: String, enumValue: MockEnumValue) {
+        self.__variables = [
+            "id": id,
+            "enumValue": GraphQLEnum(enumValue)
+        ]
+    }
+}


### PR DESCRIPTION
### What and why?

This PR fixes a crash in `GraphQLMetadataExtractor.extractVariables() `that occurs when Apollo GraphQL variables include types that are not JSON-serializable (e.g., `GraphQLEnum` or values wrapped as `__SwiftValue`).

Fixes #17.

### How?

Each variable is now converted individually using its `_jsonEncodableValue`, and we extract the resulting `_jsonValue` to ensure it is JSON-serializable. If a variable has no `_jsonEncodableValue`, we fall back to the original value.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
