### PR TITLE
Chore: Add tests for variables with non-ascii characters

### DIFF
--- a/Tests/DatadogApolloTests/DatadogApolloTests.swift
+++ b/Tests/DatadogApolloTests/DatadogApolloTests.swift
@@ -110,7 +110,7 @@ public final class DatadogApolloInterceptorTests: XCTestCase {
         XCTAssertTrue(payload.contains("user(id: $userId)"))
     }
 
-    // MARK: - GraphQL Enum Variables Tests
+    // MARK: - GraphQL Variables Tests
 
     func testExtractVariablesWithGraphQLEnum() throws {
         // Test that GraphQLEnum types are properly serialized to JSON
@@ -128,5 +128,33 @@ public final class DatadogApolloInterceptorTests: XCTestCase {
         // Verify the enum is serialized as its string value
         XCTAssertTrue(variables.contains("OPTION_B"))
         XCTAssertTrue(variables.contains("test-123"))
+    }
+
+    func testExtractVariablesWithNonASCIICharacters() throws {
+        // Test that non-ASCII characters are properly handled in variables
+        let extractor = GraphQLMetadataExtractor()
+        let variables: [String: GraphQLOperationVariableValue] = [
+            "userId": "user-123",
+            "name": "José García",
+            "city": "São Paulo",
+            "description": "Test with émojis 🎉 and spëcial çhars"
+        ]
+        let operation = MockQueryOperation(variables: variables)
+
+        let result = extractor.extractVariables(from: operation)
+
+        XCTAssertNotNil(result)
+        guard let variablesJson = result else {
+            XCTFail("Expected non-nil variables")
+            return
+        }
+
+        // Verify non-ASCII characters are preserved in the JSON output
+        XCTAssertTrue(variablesJson.contains("José García"))
+        XCTAssertTrue(variablesJson.contains("São Paulo"))
+        XCTAssertTrue(variablesJson.contains("🎉"))
+        XCTAssertTrue(variablesJson.contains("émojis"))
+        XCTAssertTrue(variablesJson.contains("spëcial"))
+        XCTAssertTrue(variablesJson.contains("çhars"))
     }
 }


### PR DESCRIPTION
### What and why?

Adds a test to test sending GraphQL requests with non-ascii characters.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
