### PR TITLE
Fix: podspec publish CI job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -105,9 +105,6 @@ Smoke Tests (iOS):
 # └──────────────┘
 
 .release-before-script: &export_MAKE_release_params
-  - export GIT_TAG=${RELEASE_GIT_TAG:-$CI_COMMIT_TAG} # CI_COMMIT_TAG if set, otherwise default to RELEASE_GIT_TAG
-  - if [ -z "$GIT_TAG" ]; then echo "GIT_TAG is not set"; exit 1; fi # sanity check
-  - export ARTIFACTS_PATH="artifacts/$GIT_TAG"
   - export DRY_RUN=${CI_COMMIT_TAG:+0} # 0 if CI_COMMIT_TAG is set
   - export DRY_RUN=${DRY_RUN:-$RELEASE_DRY_RUN} # otherwise default to RELEASE_DRY_RUN
 

--- a/Makefile
+++ b/Makefile
@@ -80,11 +80,9 @@ smoke-test-ios-all:
 
 # Publish Cocoapods podspecs to trunk
 release-publish-podspecs:
-	@$(call require_param,ARTIFACTS_PATH)
 	@:$(eval DRY_RUN ?= 1)
-	@$(ECHO_TITLE) "make release-publish-podspecs ARTIFACTS_PATH='$(ARTIFACTS_PATH)' DRY_RUN='$(DRY_RUN)'"
+	@$(ECHO_TITLE) "make release-publish-podspecs DRY_RUN='$(DRY_RUN)'"
 	DRY_RUN=$(DRY_RUN) ./tools/release/publish-podspec.sh \
-		--artifacts-path "$(ARTIFACTS_PATH)" \
 		--podspec-name "DatadogApollo.podspec"
 
 bump:

--- a/tools/release/publish-podspec.sh
+++ b/tools/release/publish-podspec.sh
@@ -18,18 +18,17 @@ source ./tools/secrets/get-secret.sh
 
 set_description "Publishes podspec to Cocoapods trunk."
 define_arg "podspec-name" "" "The name of podspec file to publish." "string" "true"
-define_arg "artifacts-path" "" "The path to build artifacts." "string" "true"
 
 check_for_help "$@"
 parse_args "$@"
 
-REPO_PATH="$artifacts_path/dd-sdk-ios-apollo-interceptor"
+REPO_PATH="$(pwd)"
 PODSPEC_PATH="$REPO_PATH/$podspec_name"
 
 authenticate() {
     echo_subtitle "Authenticate 'pod trunk' CLI"
     echo_info "Exporting 'COCOAPODS_TRUNK_TOKEN' for CI"
-    export COCOAPODS_TRUNK_TOKEN=$(get_secret $DD_IOS_SECRET__CP_TRUNK_TOKEN)
+    export COCOAPODS_TRUNK_TOKEN=$(get_secret $DD_APOLLO_SECRET__CP_TRUNK_TOKEN)
     echo_info "▸ bundle exec pod trunk me" && bundle exec pod trunk me
     if [[ $? -ne 0 ]]; then
         echo_err "Error: 'pod trunk' is not authenticated."


### PR DESCRIPTION
### What and why?

This PR fixes the CI job that publishes CocoaPods podspecs to trunk by removing unnecessary XCFramework artifact dependencies copied from dd-sdk-ios.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
