### PR TITLE
Fix: branches names in gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,8 +7,8 @@ stages:
 variables:
   V1_BRANCH: "v1"
   V2_BRANCH: "v2"
-  DEVELOP_V1_BRANCH: "develop"
-  DEVELOP_V2_BRANCH: "develop-v2"
+  DEVELOP_V1_BRANCH: "develop-v1"
+  DEVELOP_V2_BRANCH: "develop"
   DEFAULT_XCODE: "16.3.0"
   DEFAULT_IOS_OS: "18.4"
   # Prefilled variables for running a pipeline manually:


### PR DESCRIPTION
### What and why?

Fix branches names in Gitlab CI now that we renamed `develop` -> `develop-v1` and `develop-v2` to `develop`.

### Review checklist
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
