### PR TITLE
Use `String(describing:)` to preserve `GraphQLNullable` semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [FIX] Use string representation for `GraphQLNullable.none` to distinguish from `.null`
+
 # 2.0.0 / 17-12-2025
 
 Initial release of Datadog Integration for Apollo iOS supporting Apollo 2.0+.

--- a/Sources/DatadogApollo/Internal/GraphQLMetadataExtractor.swift
+++ b/Sources/DatadogApollo/Internal/GraphQLMetadataExtractor.swift
@@ -30,8 +30,8 @@ internal struct GraphQLMetadataExtractor {
             if let jsonValue = variableValue._jsonEncodableValue?._jsonValue {
                 return jsonValue
             }
-            // Fallback to NSNull for values that don't have a JSON representation
-            return NSNull()
+            // Fallback to string representation to preserve semantic information
+            return String(describing: variableValue)
         }
 
         do {

--- a/Tests/DatadogApolloTests/DatadogApolloTests.swift
+++ b/Tests/DatadogApolloTests/DatadogApolloTests.swift
@@ -170,12 +170,15 @@ public final class DatadogApolloInterceptorTests: XCTestCase {
         XCTAssertTrue(variablesJson.contains("item-456"))
         XCTAssertTrue(variablesJson.contains("optionalName"))
 
-        // Verify the nullable .none value is serialized as proper JSON null
-        XCTAssertTrue(variablesJson.contains("null"), "Expected 'null' in JSON output but got: \(variablesJson)")
+        // Verify the nullable .none value is serialized as a string representation
+        XCTAssertTrue(variablesJson.contains("none"), "Expected 'none' in JSON output but got: \(variablesJson)")
 
         // Additionally verify it's valid JSON that can be parsed back
-        guard let jsonData = variablesJson.data(using: .utf8),
-              let parsedJson = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
+        guard
+            let jsonData = variablesJson.data(using: .utf8),
+            let parsedJson = try? JSONSerialization.jsonObject(with: jsonData) as?
+            [String: Any]
+        else {
             XCTFail("Expected valid JSON output")
             return
         }
@@ -183,6 +186,8 @@ public final class DatadogApolloInterceptorTests: XCTestCase {
         // Verify the parsed JSON has the expected structure
         XCTAssertEqual(parsedJson["id"] as? String, "item-456")
         XCTAssertTrue(parsedJson.keys.contains("optionalName"))
-        XCTAssertTrue(parsedJson["optionalName"] is NSNull, "Expected NSNull for optionalName but got: \(String(describing: parsedJson["optionalName"]))")
+        // The value should be a string representation of the GraphQLNullable
+        XCTAssertTrue(parsedJson["optionalName"] is String, "Expected String for optionalName but got: \(String(describing: parsedJson["optionalName"]))")
+        XCTAssertTrue((parsedJson["optionalName"] as? String)?.contains("none") == true, "Expected string to contain 'none'")
     }
 }


### PR DESCRIPTION
### What and why?

This PR updates the fix from #32 to use `String(describing:)` instead of `NSNull()` for the serialization fallback.

GraphQL distinguishes between:
  - `GraphQLNullable.none` - variable omitted from request
  - `GraphQLNullable.null` - variable explicitly set to null

  The `NSNull()` approach conflated these two distinct states (both appeared as `null`
  in monitoring data). Using `String(describing:)` preserves the semantic difference:
  - `.none` → `"none"` (string)
  - `.null` → `null` or `"null"`
  - `.some(value)` → actual value

### Review checklist
- [x] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
- [ ] Add CHANGELOG entry for user facing changes
- [ ] Add Objective-C interface for public APIs (see our [guidelines](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3157787243/RFC+-+Modular+Objective-C+Interface#Recommended-solution) (internal) and run `make api-surface`)
