### PR TITLE
ci: migrate macOS jobs to tart VM runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,8 +21,8 @@ variables:
 
 default:
   tags:
-    - macos:sonoma
-    - specific:true
+    - macos:tart
+  image: "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/ci-platform-machine-images/tart-vm:dd-sdk-ios-apollo-interceptor-sonoma-latest"
 
 # ┌───────────────┐
 # │ Utility jobs: │


### PR DESCRIPTION
## Summary

Migrate the macOS GitLab CI jobs in this repo from dedicated `macos:sonoma` runners to virtualized `macos:tart` runners, using the repo-specific tart VM image (`dd-sdk-ios-apollo-interceptor-sonoma`).

The migration is applied at the `default:` level, so every job (`ENV check`, `Lint`, `Unit Tests`, `Smoke Tests (iOS)`) now runs on the tart VM.

**VM image:** [`packer/macos-vm/team/dd-sdk-ios-apollo-interceptor-sonoma.pkr.hcl`](https://github.com/DataDog/ci-platform-machine-images/blob/main/packer/macos-vm/team/dd-sdk-ios-apollo-interceptor-sonoma.pkr.hcl) → `486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/ci-platform-machine-images/tart-vm:dd-sdk-ios-apollo-interceptor-sonoma-latest`

## Motivation

The virtualized tart runners have a number of benefits over dedicated macOS runners:

- **Better isolation** between workloads — each job runs in a fresh VM
- **Decoupled host toolchain** — the host is independent of each team's toolchain requirements
- **Concurrency** — two jobs can run simultaneously on the same `mac2.metal` host
- **Higher utilization** of `mac2.metal` hosts → cost reduction from needing fewer instances
- **Faster provisioning and teardown** vs. the dedicated runner lifecycle

## Changes

| File | Change |
|------|--------|
| `.gitlab-ci.yml` | Switch the `default` tags from `macos:sonoma` / `specific:true` to `macos:tart` and pin the repo-specific tart VM image |

## Test plan

- [ ] Manually trigger the pipeline and verify the `ENV check`, `Lint`, `Unit Tests`, and `Smoke Tests (iOS)` jobs pass on the tart runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)
